### PR TITLE
User controllers/routes

### DIFF
--- a/environment.d.ts
+++ b/environment.d.ts
@@ -20,6 +20,7 @@ declare global {
       BASE_URL: string;
       CLIENT_ID: string;
       ISSUER: string;
+      API_KEY: string;
       HOST_URL: string;
       NODE_ENV: 'development' | 'production';
       PORT: number

--- a/feature-list.txt
+++ b/feature-list.txt
@@ -34,3 +34,5 @@ Features required
 Not required
  - Update a subscription
  - Get all subscriptions on the platform
+
+Consider testing routes by mocking controllers and checking they are called?

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "https": "/usr/bin/caddy reverse-proxy --from localhost:443 --to localhost:5000"
   },
   "dependencies": {
+    "cross-fetch": "^3.1.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "express-async-handler": "^1.2.0",

--- a/src/__tests__/getUserSubscriptions.test.ts
+++ b/src/__tests__/getUserSubscriptions.test.ts
@@ -1,0 +1,64 @@
+import { getUserSubscriptions } from '../controllers/userControllers';
+import request from 'supertest';
+import express from 'express';
+import './dbSetupTeardown';
+import { deleteSubscription, insertChannel, insertSubscription } from '../db/helpers';
+
+// Setup new app instance
+const app = express();
+
+// Use the controller
+app.get('/users/:userId/subscriptions', getUserSubscriptions);
+
+describe('getAllChannels controller', () => {
+  // Add some channels and subs to the test database
+  beforeAll(async () => {
+    await insertChannel({ channelId: '1234', channelName: 'VGBootCamp' });
+    await insertChannel({ channelId: '5678', channelName: 'BTSSmash' });
+    await insertSubscription({
+      channelId: '1234',
+      platform: 'twitch',
+      userId: '1234'
+    });
+
+    await insertSubscription({
+      channelId: '5678',
+      platform: 'twitch',
+      userId: '1234'
+    })
+  });
+
+  it("retrieves all subscriptions belonging to the specified user", async () => {
+    const res = await request(app).get(`/users/${'1234'}/subscriptions`);
+
+    expect(res.headers['content-type']).toMatch(/json/);
+    expect(res.statusCode).toEqual(200);
+    // There are two subscriptions belonging to this user in the database
+    expect(res.body).toStrictEqual([
+      {
+        "channel_id": "1234",
+        "platform": "twitch",
+        "subscription_id": 1,
+        "user_id": "1234",
+      },
+      {
+        "channel_id": "5678",
+        "platform": "twitch",
+        "subscription_id": 2,
+        "user_id": "1234",
+      }
+    ]);
+  });
+
+  it("returns empty array when no subscriptions exist in the database", async () => {
+    // Delete existing channels first
+    await deleteSubscription(1);
+    await deleteSubscription(2);
+
+    const res = await request(app).get(`/users/${'1234'}/subscriptions`);
+    expect(res.headers['content-type']).toMatch(/json/);
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toStrictEqual([]);
+  });
+});
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import 'dotenv/config';
 import { config } from './config/auth0';
 import { auth, requiresAuth } from 'express-openid-connect';
 import { errorHandler } from './middleware/errorMiddleware';
+import userRoutes from './routes/userRoutes';
 
 process.env.TEST_ENV = 'false';
 
@@ -50,7 +51,7 @@ app.get('/admin', requiresAuth(), (req, res) => {
 });
 
 // Use routes
-// app.use('/api/users', userRoutes);
+app.use('/api/users', userRoutes);
 app.use('/api/channels', channelRoutes);
 app.use('/api/subscriptions', subscriptionRoutes);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,9 @@ process.env.TEST_ENV = 'false';
 
 const app: Application = express();
 
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
 // auth router attaches /login, /logout, and /callback routes to the baseURL
 // * Although the form_post notification appears, requests should still be able to be sent fine with HTTP. If issues occur, run the npm https script
 app.use(auth(config));

--- a/src/controllers/subscriptionControllers.ts
+++ b/src/controllers/subscriptionControllers.ts
@@ -49,9 +49,9 @@ const addSubscription = [
 
     // For testing purposes, use the res.locals object, which can be changed to suit testing needs
     if (process.env.TEST_ENV === 'true') {
-      userId = res.locals.user!.sub.split('|')[1] as string
+      userId = res.locals.user!.sub as string;
     } else {
-      userId = req.oidc.user!.sub.split('|')[1] as string;
+      userId = req.oidc.user!.sub as string;
     }
 
     // Extract the validation errors from a request

--- a/src/controllers/uesrControllers.ts
+++ b/src/controllers/uesrControllers.ts
@@ -1,0 +1,40 @@
+import asyncHandler from 'express-async-handler';
+
+// @desc    Return the currently logged in user
+// @route   GET /api/users/current
+// @access  Private
+const getCurrentUser = asyncHandler(async (req, res) => {
+});
+
+
+// @desc    Get a user
+// @route   GET /api/users/:userId
+// @access  Private
+const getUser = asyncHandler(async (req, res) => {
+});
+
+// @desc    Update user details
+// @route   PUT /api/users/:userId
+// @access  Private
+const updateUser = asyncHandler(async (req, res) => {
+});
+
+// @desc    Delete user
+// @route   DELETE /api/user/:userId
+// @access  Private
+const deleteUser = asyncHandler(async (req, res) => {
+});
+
+// @desc    Get user subscriptions
+// @route   GET /api/user/:userId/subscriptions
+// @access  Private
+const getUserSubscriptions = asyncHandler(async (req, res) => {
+});
+
+export {
+  getCurrentUser,
+  getUser,
+  updateUser,
+  deleteUser,
+  getUserSubscriptions
+}

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -39,9 +39,28 @@ const updateUser = asyncHandler(async (req, res) => {
 });
 
 // @desc    Delete user
-// @route   DELETE /api/user/:userId
+// @route   DELETE /api/users/:userId
 // @access  Private
 const deleteUser = asyncHandler(async (req, res) => {
+  // Call Auth0 API with appropriate Bearer token
+  const response = await fetch(`${process.env.ISSUER}/api/v2/users/${req.params.userId}`, {
+    method: 'delete',
+    headers: {
+      'Authorization': `Bearer ${process.env.API_KEY}`,
+    },
+  });
+
+  console.log(response);
+
+
+  if (response.status === 204) {    // indicates the user either does not exist, or has been deleted. Treat as success
+    // 204 status indicates no content, hence a 200 is used to attach some feedback
+    res.status(200).json({ message: 'User deleted' });
+  } else {    // Error occurred, handle accordingly
+    const data = await response.json();
+    res.status(data.statusCode);
+    throw new Error(data.message)
+  }
 });
 
 // @desc    Get user subscriptions

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -5,6 +5,9 @@ import fetch from 'cross-fetch';
 // @route   GET /api/users/current
 // @access  Private
 const getCurrentUser = asyncHandler(async (req, res) => {
+  // As a protected route, this function will always have access to req.oidc.user
+  const userData = req.oidc.user;
+  res.json(userData);
 });
 
 
@@ -12,7 +15,7 @@ const getCurrentUser = asyncHandler(async (req, res) => {
 // @route   GET /api/users/:userId
 // @access  Private
 const getUser = asyncHandler(async (req, res) => {
-  // As a protected route, this controller will always have access to req.oidc.user
+  // Call Auth0 API with appropriate Bearer token
   const response = await fetch(`${process.env.ISSUER}/api/v2/users/${req.params.userId}`, {
     method: 'get',
     headers: {
@@ -20,10 +23,8 @@ const getUser = asyncHandler(async (req, res) => {
     },
   });
   const data = await response.json();
-  console.log(data);
-
-
-  res.send('body');
+  // * This does not expose sensitive data (i.e. password)
+  res.json(data);
 });
 
 // @desc    Update user details

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -123,7 +123,7 @@ const getPasswordChange = asyncHandler(async (req, res) => {
   const passwordChangeOptions = {
     client_id: process.env.CLIENT_ID,
     email: userData.email,
-    connection: userData.identities[0].connection
+    // connection: userData.identities[0].connection
   }
 
   // Make POST request with user data
@@ -150,26 +150,10 @@ const getPasswordChange = asyncHandler(async (req, res) => {
 // @route   GET /api/users/:userId/email-verification
 // @access  Private
 const getEmailVerification = asyncHandler(async (req, res) => {
-  // First fetch all user details (specifically to access connection type)
-  const getUserResponse = await fetch(`${process.env.ISSUER}/api/v2/users/${req.params.userId}`, {
-    method: 'get',
-    headers: {
-      'Authorization': `Bearer ${process.env.API_KEY}`,
-    },
-  });
-
-  const userData = await getUserResponse.json();
-
-  if (userData.error) {   // successful fetch, but either bad request or user does not exist. Throw error
-    res.status(userData.statusCode);
-    throw new Error(userData.message)
-  }
-
   // User data successfully fetched - now able to construct POST request to send email verification
   const emailVerifyOptions = {
-    user_id: userData.user_id,
+    user_id: req.params.userId,
     client_id: process.env.CLIENT_ID,
-    // identity: userData.identities[0],
   }
 
   // Make POST request with user data
@@ -189,7 +173,7 @@ const getEmailVerification = asyncHandler(async (req, res) => {
     throw new Error(emailResponseData.message)
   }
 
-  res.json({ message: 'Password reset email sent' })
+  res.json({ message: 'Email verification link sent' })
 });
 
 // @desc    Get user subscriptions

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -1,6 +1,7 @@
 import asyncHandler from 'express-async-handler';
 import fetch from 'cross-fetch';
 import { body, validationResult } from 'express-validator';
+import { selectUserSubscriptions } from '../db/helpers';
 
 // @desc    Return the currently logged in user
 // @route   GET /api/users/current
@@ -36,6 +37,7 @@ const getUser = asyncHandler(async (req, res) => {
 // @desc    Update user details
 // @route   PUT /api/users/:userId
 // @access  Private
+// * Does not resend verification email on email address change, but will set email_verified to false automatically
 const updateUser = [
   // Validate input. Only these details are changeable. These are validated by Auth0 as well so this may be redundant. But this does provide an easier way to give useful error messages
   body('email', 'Email is required').trim().isString().isLength({ min: 1 }),
@@ -147,6 +149,8 @@ const getPasswordChange = asyncHandler(async (req, res) => {
 // @route   GET /api/user/:userId/subscriptions
 // @access  Private
 const getUserSubscriptions = asyncHandler(async (req, res) => {
+  const result = await selectUserSubscriptions(req.params.userId);
+  res.json(result.rows);
 });
 
 export {

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -12,7 +12,8 @@ const getCurrentUser = asyncHandler(async (req, res) => {
 // @route   GET /api/users/:userId
 // @access  Private
 const getUser = asyncHandler(async (req, res) => {
-  const response = await fetch(`${process.env.ISSUER}/api/v2/users`, {
+  // As a protected route, this controller will always have access to req.oidc.user
+  const response = await fetch(`${process.env.ISSUER}/api/v2/users/${req.params.userId}`, {
     method: 'get',
     headers: {
       'Authorization': `Bearer ${process.env.API_KEY}`,

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -1,4 +1,5 @@
 import asyncHandler from 'express-async-handler';
+import fetch from 'cross-fetch';
 
 // @desc    Return the currently logged in user
 // @route   GET /api/users/current
@@ -11,6 +12,17 @@ const getCurrentUser = asyncHandler(async (req, res) => {
 // @route   GET /api/users/:userId
 // @access  Private
 const getUser = asyncHandler(async (req, res) => {
+  const response = await fetch(`${process.env.ISSUER}/api/v2/users`, {
+    method: 'get',
+    headers: {
+      'Authorization': `Bearer ${process.env.API_KEY}`,
+    },
+  });
+  const data = await response.json();
+  console.log(data);
+
+
+  res.send('body');
 });
 
 // @desc    Update user details

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -7,7 +7,7 @@ import fetch from 'cross-fetch';
 const getCurrentUser = asyncHandler(async (req, res) => {
   // As a protected route, this function will always have access to req.oidc.user
   const userData = req.oidc.user;
-  res.json(userData);
+  res.status(200).json(userData);
 });
 
 
@@ -23,8 +23,13 @@ const getUser = asyncHandler(async (req, res) => {
     },
   });
   const data = await response.json();
-  // * This does not expose sensitive data (i.e. password)
-  res.json(data);
+
+  if (data.error) {   // successful fetch, but either bad request or user does not exist. Throw error
+    res.status(data.statusCode);
+    throw new Error(data.message)
+  }
+
+  res.status(200).json(data);
 });
 
 // @desc    Update user details

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,16 +1,19 @@
 import express from 'express';
 import { requiresAuth } from 'express-openid-connect';
-import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions } from '../controllers/userControllers';
+import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions, getPasswordChange } from '../controllers/userControllers';
 const router = express.Router();
 
 // Base path /api/users
 
 router.get('/current', requiresAuth(), getCurrentUser);
 router.route('/:userId')
-  .get(getUser)
-  .delete(deleteUser)
-  .put(updateUser);
+  .get(requiresAuth(), getUser)
+  .delete(requiresAuth(), deleteUser)
+  .patch(updateUser);
+
 router.route('/:userId/subscriptions').get(getUserSubscriptions);
+router.route('/:userId/password-change').get(getPasswordChange);
+// router.route('/:userId/email-verification').get(getPasswordChange);
 
 
 export default router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions } from '../controllers/uesrControllers';
+import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions } from '../controllers/userControllers';
 const router = express.Router();
 
 // Base path /api/users

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,10 +1,11 @@
 import express from 'express';
+import { requiresAuth } from 'express-openid-connect';
 import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions } from '../controllers/userControllers';
 const router = express.Router();
 
 // Base path /api/users
 
-router.get('/current', getCurrentUser);
+router.get('/current', requiresAuth(), getCurrentUser);
 router.route('/:userId')
   .get(getUser)
   .delete(deleteUser)

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -11,9 +11,9 @@ router.route('/:userId')
   .delete(requiresAuth(), deleteUser)
   .patch(requiresAuth(), updateUser);
 
-router.route('/:userId/subscriptions').get(getUserSubscriptions);
+router.route('/:userId/subscriptions').get(requiresAuth(), getUserSubscriptions);
 router.route('/:userId/password-change').get(requiresAuth(), getPasswordChange);
-router.route('/:userId/email-verification').get(getEmailVerification);
+router.route('/:userId/email-verification').get(requiresAuth(), getEmailVerification);
 
 
 export default router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,25 +1,15 @@
 import express from 'express';
+import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions } from '../controllers/uesrControllers';
 const router = express.Router();
-import asyncHandler from 'express-async-handler'
 
 // Base path /api/users
 
-router.get('/', asyncHandler(async (req, res) => {
-  res.send('User route')
-}));
+router.get('/current', getCurrentUser);
+router.route('/:userId')
+  .get(getUser)
+  .delete(deleteUser)
+  .put(updateUser);
+router.route('/:userId/subscriptions').get(getUserSubscriptions);
 
-router.get('/login', (req, res) => {
-  res.send('Protected login route')
-});
-router.post('/logout', (req, res) => {
-  res.send('Logout route')
-});
-router.post('/register', (req, res) => {
-  res.send('Register route')
-});
-// router.route('/:userId')
-//   .get(protectRoute, getUser)
-//   .delete(protectRoute, deleteUser)
-//   .put(protectRoute, updateUser);
 
 export default router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -9,10 +9,10 @@ router.get('/current', requiresAuth(), getCurrentUser);
 router.route('/:userId')
   .get(requiresAuth(), getUser)
   .delete(requiresAuth(), deleteUser)
-  .patch(updateUser);
+  .patch(requiresAuth(), updateUser);
 
 router.route('/:userId/subscriptions').get(getUserSubscriptions);
-router.route('/:userId/password-change').get(getPasswordChange);
+router.route('/:userId/password-change').get(requiresAuth(), getPasswordChange);
 // router.route('/:userId/email-verification').get(getPasswordChange);
 
 

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { requiresAuth } from 'express-openid-connect';
-import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions, getPasswordChange } from '../controllers/userControllers';
+import { getCurrentUser, getUser, updateUser, deleteUser, getUserSubscriptions, getPasswordChange, getEmailVerification } from '../controllers/userControllers';
 const router = express.Router();
 
 // Base path /api/users
@@ -13,7 +13,7 @@ router.route('/:userId')
 
 router.route('/:userId/subscriptions').get(getUserSubscriptions);
 router.route('/:userId/password-change').get(requiresAuth(), getPasswordChange);
-// router.route('/:userId/email-verification').get(getPasswordChange);
+router.route('/:userId/email-verification').get(getEmailVerification);
 
 
 export default router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,6 +1400,13 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
@@ -2840,6 +2847,13 @@ negotiator@0.6.3:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
@@ -3669,6 +3683,11 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-jest@^28.0.3:
   version "28.0.3"
   resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.3.tgz"
@@ -3826,6 +3845,19 @@ walker@^1.0.7:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
This PR adds all user-related API routes and controllers. Namely, this includes
1. Getting the currently logged in user
2. Get any user by ID
3. Get a user's subscriptions
4. Update a user
5. Delete a user
6. Resend an email verification link
7. Change a user's password

These are largely untested at this stage because they are essentially full of API calls to Auth0's API rather than a custom implementation of these features. With extensive mocking it might be possible to test, but the tests would be so brittle, and would barely be testing anything unique.